### PR TITLE
refactor config class into a define

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,25 +9,9 @@ class pgbackrest::config(
   String $filename   = '/etc/pgbackrest.conf',
   Boolean $show_diff = true,
 ) {
-  # Add each section block configs
-  $pgbackrest::config.each |String $section, Hash $settings| {
-    $settings.each |String $name, String $value| {
-      # Remove values not defined or empty
-      $is_present = $value ? {
-        undef   => 'absent',
-        ''      => 'absent',
-        default => 'present',
-      }
-
-      # Write the configuration options to pgbackrest::config::filename
-      ini_setting { "${section} ${name}":
-        ensure    => $is_present,
-        path      => $filename,
-        section   => $section,
-        setting   => $name,
-        value     => $value,
-        show_diff => $show_diff,
-      }
-    }
+  pgbackrest::config_file { $filename:
+    filename  => $filename,
+    show_diff => $show_diff,
+    config    => $pgbackrest::config,
   }
 }

--- a/manifests/config_file.pp
+++ b/manifests/config_file.pp
@@ -1,0 +1,28 @@
+# @summary Write a pgbackrest configuration file snippet
+define pgbackrest::config_file(
+  Hash[String,Hash] $config,
+  String $filename   = "/etc/pgbackrest/conf.d/${name}.conf",
+  Boolean $show_diff = true,
+) {
+  # Add each section block configs
+  $config.each |String $section, Hash $settings| {
+    $settings.each |String $name, String $value| {
+      # Remove values not defined or empty
+      $is_present = $value ? {
+        undef   => 'absent',
+        ''      => 'absent',
+        default => 'present',
+      }
+
+      # Write the configuration options to pgbackrest::config::filename
+      ini_setting { "${section} ${name}":
+        ensure    => $is_present,
+        path      => $filename,
+        section   => $section,
+        setting   => $name,
+        value     => $value,
+        show_diff => $show_diff,
+      }
+    }
+  }
+}


### PR DESCRIPTION
This leaves the actual class unchanged, but allows reusing the file creation logic to create more config files, by default in a conf.d directory.